### PR TITLE
Expose `SerilogLoggerFactory`

### DIFF
--- a/src/Serilog.AspNetCore/AspNetCore/SerilogLoggerFactory.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/SerilogLoggerFactory.cs
@@ -18,26 +18,49 @@ using Serilog.Extensions.Logging;
 
 namespace Serilog.AspNetCore
 {
-    public class SerilogLoggerFactory : ILoggerFactory
+	/// <summary>
+	/// Implements Microsoft's ILoggerFactory so that we can inject Serilog Logger.
+	/// </summary>
+	/// <seealso cref="Microsoft.Extensions.Logging.ILoggerFactory" />
+	public class SerilogLoggerFactory : ILoggerFactory
     {
         readonly SerilogLoggerProvider _provider;
 
-        public SerilogLoggerFactory(Serilog.ILogger logger = null, bool dispose = false)
+		/// <summary>
+		/// Initializes a new instance of the <see cref="SerilogLoggerFactory"/> class.
+		/// </summary>
+		/// <param name="logger">The logger.</param>
+		/// <param name="dispose">if set to <c>true</c> [dispose].</param>
+		public SerilogLoggerFactory(Serilog.ILogger logger = null, bool dispose = false)
         {
             _provider = new SerilogLoggerProvider(logger, dispose);
         }
 
-        public void Dispose()
+		/// <summary>
+		/// Disposes the provider.
+		/// </summary>
+		public void Dispose()
         {
             _provider.Dispose();
         }
 
-        public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName)
+		/// <summary>
+		/// Creates a new <see cref="T:Microsoft.Extensions.Logging.ILogger" /> instance.
+		/// </summary>
+		/// <param name="categoryName">The category name for messages produced by the logger.</param>
+		/// <returns>
+		/// The <see cref="T:Microsoft.Extensions.Logging.ILogger" />.
+		/// </returns>
+		public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName)
         {
             return _provider.CreateLogger(categoryName);
         }
 
-        public void AddProvider(ILoggerProvider provider)
+		/// <summary>
+		/// Adds an <see cref="T:Microsoft.Extensions.Logging.ILoggerProvider" /> to the logging system.
+		/// </summary>
+		/// <param name="provider">The <see cref="T:Microsoft.Extensions.Logging.ILoggerProvider" />.</param>
+		public void AddProvider(ILoggerProvider provider)
         {
             SelfLog.WriteLine("Ignoring added logger provider {0}", provider);
         }

--- a/src/Serilog.AspNetCore/AspNetCore/SerilogLoggerFactory.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/SerilogLoggerFactory.cs
@@ -18,49 +18,50 @@ using Serilog.Extensions.Logging;
 
 namespace Serilog.AspNetCore
 {
-	/// <summary>
-	/// Implements Microsoft's ILoggerFactory so that we can inject Serilog Logger.
-	/// </summary>
-	/// <seealso cref="Microsoft.Extensions.Logging.ILoggerFactory" />
-	public class SerilogLoggerFactory : ILoggerFactory
+    /// <summary>
+    /// Implements <see cref="ILoggerFactory"/> so that we can inject Serilog Logger.
+    /// </summary>
+    public class SerilogLoggerFactory : ILoggerFactory
     {
-        readonly SerilogLoggerProvider _provider;
+        private readonly SerilogLoggerProvider _provider;
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="SerilogLoggerFactory"/> class.
-		/// </summary>
-		/// <param name="logger">The logger.</param>
-		/// <param name="dispose">if set to <c>true</c> [dispose].</param>
-		public SerilogLoggerFactory(Serilog.ILogger logger = null, bool dispose = false)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SerilogLoggerFactory"/> class.
+        /// </summary>
+        /// <param name="logger">The Serilog logger; if not supplied, the static <see cref="Serilog.Log"/> will be used.</param>
+        /// <param name="dispose">When true, dispose <paramref name="logger"/> when the framework disposes the provider. If the
+        /// logger is not specified but <paramref name="dispose"/> is true, the <see cref="Log.CloseAndFlush()"/> method will be
+        /// called on the static <see cref="Log"/> class instead.</param>
+        public SerilogLoggerFactory(ILogger logger = null, bool dispose = false)
         {
             _provider = new SerilogLoggerProvider(logger, dispose);
         }
 
-		/// <summary>
-		/// Disposes the provider.
-		/// </summary>
-		public void Dispose()
+        /// <summary>
+        /// Disposes the provider.
+        /// </summary>
+        public void Dispose()
         {
             _provider.Dispose();
         }
 
-		/// <summary>
-		/// Creates a new <see cref="T:Microsoft.Extensions.Logging.ILogger" /> instance.
-		/// </summary>
-		/// <param name="categoryName">The category name for messages produced by the logger.</param>
-		/// <returns>
-		/// The <see cref="T:Microsoft.Extensions.Logging.ILogger" />.
-		/// </returns>
-		public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName)
+        /// <summary>
+        /// Creates a new <see cref="T:Microsoft.Extensions.Logging.ILogger" /> instance.
+        /// </summary>
+        /// <param name="categoryName">The category name for messages produced by the logger.</param>
+        /// <returns>
+        /// The <see cref="T:Microsoft.Extensions.Logging.ILogger" />.
+        /// </returns>
+        public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName)
         {
             return _provider.CreateLogger(categoryName);
         }
 
-		/// <summary>
-		/// Adds an <see cref="T:Microsoft.Extensions.Logging.ILoggerProvider" /> to the logging system.
-		/// </summary>
-		/// <param name="provider">The <see cref="T:Microsoft.Extensions.Logging.ILoggerProvider" />.</param>
-		public void AddProvider(ILoggerProvider provider)
+        /// <summary>
+        /// Adds an <see cref="T:Microsoft.Extensions.Logging.ILoggerProvider" /> to the logging system.
+        /// </summary>
+        /// <param name="provider">The <see cref="T:Microsoft.Extensions.Logging.ILoggerProvider" />.</param>
+        public void AddProvider(ILoggerProvider provider)
         {
             SelfLog.WriteLine("Ignoring added logger provider {0}", provider);
         }

--- a/src/Serilog.AspNetCore/AspNetCore/SerilogLoggerFactory.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/SerilogLoggerFactory.cs
@@ -18,7 +18,7 @@ using Serilog.Extensions.Logging;
 
 namespace Serilog.AspNetCore
 {
-    class SerilogLoggerFactory : ILoggerFactory
+    public class SerilogLoggerFactory : ILoggerFactory
     {
         readonly SerilogLoggerProvider _provider;
 


### PR DESCRIPTION
I needed to retrieve some configuration prior to registering the logger. `UseSerilog` is invoked before the `Startup` class. I sought to register the Factory manually but found out that is internal. I think that `SerilogLoggerFactory` is the main take away from this library and therefore exposing it would make it more flexible for those who don't want to use the extension methods.