### PR TITLE
UseSerilogRequestLogging()

### DIFF
--- a/samples/EarlyInitializationSample/Controllers/HomeController.cs
+++ b/samples/EarlyInitializationSample/Controllers/HomeController.cs
@@ -1,29 +1,38 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading;
 using Microsoft.AspNetCore.Mvc;
 using EarlyInitializationSample.Models;
 using Microsoft.Extensions.Logging;
+using Serilog;
 
 namespace EarlyInitializationSample.Controllers
 {
     public class HomeController : Controller
     {
-        readonly ILogger<HomeController> _logger;
+        static int _callCount;
 
-        public HomeController(ILogger<HomeController> logger)
+        readonly ILogger<HomeController> _logger;
+        readonly IDiagnosticContext _diagnosticContext;
+
+        public HomeController(ILogger<HomeController> logger, IDiagnosticContext diagnosticContext)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _diagnosticContext = diagnosticContext ?? throw new ArgumentNullException(nameof(diagnosticContext));
         }
 
         public IActionResult Index()
         {
             _logger.LogInformation("Hello, world!");
+
+            _diagnosticContext.Add("IndexCallCount", Interlocked.Increment(ref _callCount));
+
             return View();
         }
 
         public IActionResult Privacy()
         {
-            return View();
+            throw new InvalidOperationException("Something went wrong.");
         }
 
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]

--- a/samples/EarlyInitializationSample/Program.cs
+++ b/samples/EarlyInitializationSample/Program.cs
@@ -21,7 +21,10 @@ namespace EarlyInitializationSample
             Log.Logger = new LoggerConfiguration()
                 .ReadFrom.Configuration(Configuration)
                 .Enrich.FromLogContext()
-                .WriteTo.Console()
+                .WriteTo.Console(
+                    // {Properties:j} added:
+                    outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} " +
+                                    "{Properties:j}{NewLine}{Exception}")
                 .CreateLogger();
 
             try

--- a/samples/EarlyInitializationSample/Startup.cs
+++ b/samples/EarlyInitializationSample/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Serilog;
 
 namespace EarlyInitializationSample
 {
@@ -45,6 +46,11 @@ namespace EarlyInitializationSample
             {
                 app.UseExceptionHandler("/Home/Error");
             }
+
+            // Write streamlined request completion events, instead of the more verbose ones from the framework.
+            // To use the default framework request logging instead, remove this line and set the "Microsoft"
+            // level in appsettings.json to "Information".
+            app.UseSerilogRequestLogging();
 
             app.UseStaticFiles();
             app.UseCookiePolicy();

--- a/samples/EarlyInitializationSample/appsettings.json
+++ b/samples/EarlyInitializationSample/appsettings.json
@@ -3,7 +3,7 @@
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
-        "Microsoft": "Information",
+        "Microsoft": "Warning",
         "System": "Warning"
       }
     }

--- a/samples/InlineInitializationSample/Controllers/HomeController.cs
+++ b/samples/InlineInitializationSample/Controllers/HomeController.cs
@@ -1,23 +1,32 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Threading;
 using Microsoft.AspNetCore.Mvc;
 using InlineInitializationSample.Models;
 using Microsoft.Extensions.Logging;
+using Serilog;
 
 namespace InlineInitializationSample.Controllers
 {
     public class HomeController : Controller
     {
-        readonly ILogger<HomeController> _logger;
+        static int _callCount = 0;
 
-        public HomeController(ILogger<HomeController> logger)
+        readonly ILogger<HomeController> _logger;
+        readonly IDiagnosticContext _diagnosticContext;
+
+        public HomeController(ILogger<HomeController> logger, IDiagnosticContext diagnosticContext)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _diagnosticContext = diagnosticContext ?? throw new ArgumentNullException(nameof(diagnosticContext));
         }
 
         public IActionResult Index()
         {
             _logger.LogInformation("Hello, world!");
+
+            _diagnosticContext.Add("IndexCallCount", Interlocked.Increment(ref _callCount));
+
             return View();
         }
 

--- a/samples/InlineInitializationSample/Controllers/HomeController.cs
+++ b/samples/InlineInitializationSample/Controllers/HomeController.cs
@@ -10,7 +10,7 @@ namespace InlineInitializationSample.Controllers
 {
     public class HomeController : Controller
     {
-        static int _callCount = 0;
+        static int _callCount;
 
         readonly ILogger<HomeController> _logger;
         readonly IDiagnosticContext _diagnosticContext;
@@ -32,7 +32,7 @@ namespace InlineInitializationSample.Controllers
 
         public IActionResult Privacy()
         {
-            return View();
+            throw new InvalidOperationException("Something went wrong.");
         }
 
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]

--- a/samples/InlineInitializationSample/Program.cs
+++ b/samples/InlineInitializationSample/Program.cs
@@ -17,6 +17,9 @@ namespace InlineInitializationSample
                 .UseSerilog((hostingContext, loggerConfiguration) => loggerConfiguration
                     .ReadFrom.Configuration(hostingContext.Configuration)
                     .Enrich.FromLogContext()
-                    .WriteTo.Console());
+                    .WriteTo.Console(
+                        // {Properties:j} added:
+                        outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} " +
+                                        "{Properties:j}{NewLine}{Exception}"));
     }
 }

--- a/samples/InlineInitializationSample/Startup.cs
+++ b/samples/InlineInitializationSample/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Serilog;
 
 namespace InlineInitializationSample
 {
@@ -45,6 +46,11 @@ namespace InlineInitializationSample
             {
                 app.UseExceptionHandler("/Home/Error");
             }
+
+            // Write streamlined request completion events, instead of the more verbose ones from the framework.
+            // To use the default framework request logging instead, remove this line and set the "Microsoft"
+            // level in appsettings.json to "Information".
+            app.UseSerilogRequestLogging();
 
             app.UseStaticFiles();
             app.UseCookiePolicy();

--- a/samples/InlineInitializationSample/appsettings.json
+++ b/samples/InlineInitializationSample/appsettings.json
@@ -3,7 +3,7 @@
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
-        "Microsoft": "Information",
+        "Microsoft": "Warning",
         "System": "Warning"
       }
     }

--- a/src/Serilog.AspNetCore/AspNetCore/RequestCompletionMiddleware.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/RequestCompletionMiddleware.cs
@@ -1,0 +1,93 @@
+﻿// Copyright 2019 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Serilog.Events;
+using Serilog.Extensions.Hosting;
+using Serilog.Parsing;
+
+namespace Serilog.AspNetCore
+{
+    class RequestLoggingMiddleware
+    {
+        // We may, at some future point, wish to allow customization of the template used in completion events.
+        const int MessageTemplatePlaceholderCount = 4;
+        static readonly MessageTemplate MessageTemplate =
+            new MessageTemplateParser().Parse("HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms");
+
+        readonly RequestDelegate _next;
+        readonly DiagnosticContext _diagnosticContext;
+
+        public RequestLoggingMiddleware(RequestDelegate next, DiagnosticContext diagnosticContext)
+        {
+            _next = next ?? throw new ArgumentNullException(nameof(next));
+            _diagnosticContext = diagnosticContext ?? throw new ArgumentNullException(nameof(diagnosticContext));
+        }
+
+        // ReSharper disable once UnusedMember.Global
+        public async Task Invoke(HttpContext httpContext)
+        {
+            if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
+
+            var start = Stopwatch.GetTimestamp();
+            var collector = _diagnosticContext.BeginCollection();
+            try
+            {
+                await _next(httpContext);
+                var elapsedMs = GetElapsedMilliseconds(start, Stopwatch.GetTimestamp());
+                var statusCode = httpContext.Response?.StatusCode;
+                LogCompletion(httpContext, collector, statusCode, elapsedMs, null);
+            }
+            // Never caught, because `LogCompletion()` returns false.
+            catch (Exception ex) when (LogCompletion(httpContext, collector, 500, GetElapsedMilliseconds(start, Stopwatch.GetTimestamp()), ex)) { }
+        }
+
+        static bool LogCompletion(HttpContext httpContext, DiagnosticContextCollector collector, int? statusCode, double elapsedMs, Exception ex)
+        {
+            var level = statusCode > 499 ? LogEventLevel.Error : LogEventLevel.Information;
+
+            if (!Log.IsEnabled(level)) return false;
+            
+            if (!collector.TryComplete(out var properties))
+                properties = new List<LogEventProperty>();
+
+            properties.Capacity = properties.Count + MessageTemplatePlaceholderCount;
+
+            // Last-in (rightly) wins...
+            properties.Add(new LogEventProperty("RequestMethod", new ScalarValue(httpContext.Request.Method)));
+            properties.Add(new LogEventProperty("RequestPath", new ScalarValue(GetPath(httpContext))));
+            properties.Add(new LogEventProperty("StatusCode", new ScalarValue(statusCode)));
+            properties.Add(new LogEventProperty("Elapsed", new ScalarValue(elapsedMs)));
+            var evt = new LogEvent(DateTimeOffset.Now, level, ex, MessageTemplate, properties);
+            Log.Write(evt);
+
+            return false;
+        }
+
+        static double GetElapsedMilliseconds(long start, long stop)
+        {
+            return (stop - start) * 1000 / (double)Stopwatch.Frequency;
+        }
+        
+        static string GetPath(HttpContext httpContext)
+        {
+            return httpContext.Features.Get<IHttpRequestFeature>()?.RawTarget ?? httpContext.Request.Path.ToString();
+        }
+    }
+}

--- a/src/Serilog.AspNetCore/AspNetCore/SerilogLoggerFactory.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/SerilogLoggerFactory.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 using Serilog.Debugging;
 using Serilog.Extensions.Logging;
@@ -23,6 +24,7 @@ namespace Serilog.AspNetCore
     /// Implements <see cref="ILoggerFactory"/> so that we can inject Serilog Logger.
     /// </summary>
     [Obsolete("Replaced with Serilog.Extensions.Logging.SerilogLoggerFactory")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class SerilogLoggerFactory : ILoggerFactory
     {
         private readonly SerilogLoggerProvider _provider;

--- a/src/Serilog.AspNetCore/RequestLoggingOptions.cs
+++ b/src/Serilog.AspNetCore/RequestLoggingOptions.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2019 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Serilog
+{
+    class RequestLoggingOptions
+    {
+        public string MessageTemplate { get; }
+
+        public RequestLoggingOptions(string messageTemplate)
+        {
+            MessageTemplate = messageTemplate ?? throw new ArgumentNullException(nameof(messageTemplate));
+        }
+    }
+}

--- a/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
+++ b/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <ProjectReference Include="..\..\..\serilog-extensions-hosting\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
+++ b/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
@@ -24,11 +24,11 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0-*" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.0-*" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
-    <ProjectReference Include="..\..\..\serilog-extensions-hosting\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.AspNetCore/SerilogApplicationBuilderExtensions.cs
+++ b/src/Serilog.AspNetCore/SerilogApplicationBuilderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2017-2019 Serilog Contributors
+﻿// Copyright 2019 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,9 @@ namespace Serilog
     /// </summary>
     public static class SerilogApplicationBuilderExtensions
     {
+        const string DefaultRequestCompletionMessageTemplate =
+            "HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms";
+
         /// <summary>
         /// Adds middleware for streamlined request logging. Instead of writing HTTP request information
         /// like method, path, timing, status code and exception details
@@ -31,11 +34,20 @@ namespace Serilog
         /// in <c>Startup.cs</c> before any handlers whose activities should be logged.
         /// </summary>
         /// <param name="app">The application builder.</param>
+        /// <param name="messageTemplate">The message template to use when logging request completion
+        /// events. The default is
+        /// <c>"HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms"</c>. The
+        /// template can contain any of the placeholders from the default template, names of properties
+        /// added by ASP.NET Core, and names of properties added to the <see cref="IDiagnosticContext"/>.
+        /// </param>
         /// <returns>The application builder.</returns>
-        public static IApplicationBuilder UseSerilogRequestLogging(this IApplicationBuilder app)
+        public static IApplicationBuilder UseSerilogRequestLogging(
+            this IApplicationBuilder app,
+            string messageTemplate = DefaultRequestCompletionMessageTemplate)
         {
             if (app == null) throw new ArgumentNullException(nameof(app));
-            return app.UseMiddleware<RequestLoggingMiddleware>();
+            if (messageTemplate == null) throw new ArgumentNullException(nameof(messageTemplate));
+            return app.UseMiddleware<RequestLoggingMiddleware>(new RequestLoggingOptions(messageTemplate));
         }
     }
 }

--- a/src/Serilog.AspNetCore/SerilogApplicationBuilderExtensions.cs
+++ b/src/Serilog.AspNetCore/SerilogApplicationBuilderExtensions.cs
@@ -1,0 +1,41 @@
+﻿// Copyright 2017-2019 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Microsoft.AspNetCore.Builder;
+using Serilog.AspNetCore;
+
+namespace Serilog
+{
+    /// <summary>
+    /// Extends <see cref="IApplicationBuilder"/> with methods for configuring Serilog features.
+    /// </summary>
+    public static class SerilogApplicationBuilderExtensions
+    {
+        /// <summary>
+        /// Adds middleware for streamlined request logging. Instead of writing HTTP request information
+        /// like method, path, timing, status code and exception details
+        /// in several events, this middleware collects information during the request (including from
+        /// <see cref="IDiagnosticContext"/>), and writes a single event at request completion. Add this
+        /// in <c>Startup.cs</c> before any handlers whose activities should be logged.
+        /// </summary>
+        /// <param name="app">The application builder.</param>
+        /// <returns>The application builder.</returns>
+        public static IApplicationBuilder UseSerilogRequestLogging(this IApplicationBuilder app)
+        {
+            if (app == null) throw new ArgumentNullException(nameof(app));
+            return app.UseMiddleware<RequestLoggingMiddleware>();
+        }
+    }
+}


### PR DESCRIPTION
This long-talked-about feature adds middleware for request logging, based on the popular sample in [this blog post](https://blog.datalust.co/smart-logging-middleware-for-asp-net-core/).

In comparison with the default request logging performed by the framework, this implementation condenses as much information as possible into a single event, resulting in easier correlation and lower log volumes.

An example completion event might look like:

```
[15:31:09 INF] HTTP GET / responded 200 in 13.8298 ms {"RequestId": "0HLNOCKKFBOL3:00000003",
    "CorrelationId": null, "ConnectionId": "0HLNOCKKFBOL3"}
```

(I'm using the `{Properties:j}` output formatting option to include properties not present in the log message itself. This makes the events a bit noisier, but it's easier to see what's going on.)

Additional properties can be added to the completion event using `IDiagnosticContext`; e.g. in the _InlineInitializationSample_ project's `HomeController.Index()`:

```csharp
public class HomeController : Controller
{
    static int _callCount = 0;

    readonly ILogger<HomeController> _logger;
    readonly IDiagnosticContext _diagnosticContext;

    public HomeController(ILogger<HomeController> logger, IDiagnosticContext diagnosticContext)
    {
        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
        _diagnosticContext = diagnosticContext ??
             throw new ArgumentNullException(nameof(diagnosticContext));
    }

    public IActionResult Index()
    {
        _logger.LogInformation("Hello, world!");

        _diagnosticContext.Add("IndexCallCount", Interlocked.Increment(ref _callCount));

        return View();
    }
}
```

The `_diagnosticContext.Add()` call will attach `IndexCallCount` to completion events, e.g.:

```
[15:31:09 INF] Hello, world! {"SourceContext": "InlineInitializationSample.Controllers.HomeController"
    "ActionId": "3845d8d0-9e30-4264-b47a-ff72d4421038", "ActionName":
    "InlineInitializationSample.Controllers.HomeController.Index (InlineInitializationSample)",
    "RequestId": "0HLNOCKKFBOL3:00000003", "RequestPath": "/", "CorrelationId": null,
    "ConnectionId": "0HLNOCKKFBOL3"}
[15:31:09 INF] HTTP GET / responded 200 in 13.8298 ms {"IndexCallCount": 2, "RequestId":
    "0HLNOCKKFBOL3:00000003", "CorrelationId": null, "ConnectionId": "0HLNOCKKFBOL3"}
```

By doing this, it's no longer necessary to speculatively include a lot of information in the request completion event: users who want more details (e.g. form fields from the request, headers, etc.), can write middleware that depends on `IDiagnosticContext` and simply add these themselves.

Open to all opinions, including on:

 - Localization/template customization - should we allow the text of the request completion message to be customized in the first version?
 - Conditional logging - should we provide a leveled or predicate-based method of choosing which requests to log?
 - Formatting - it's usual in many style guides to omit a space between numbers and SI unit abbreviations, e.g. `123.456ms` vs `123.456 ms`; in a cluttered log event I find the former a bit harder to quickly scan so I've gone with the latter.

The PR also replicates some changes, and depends on others, in https://github.com/serilog/serilog-extensions-hosting/pull/9. In particular, `UseSerilog()` will now register the `IDiagnosticContext` and `DiagnosticContext` types, as well as `ILogger` if available, and the middleware consumes `DiagnosticContext`. CC @andrewlock.
