### PR TITLE
Include 'double elapsedMs' in the function signature of the GetLevel delegate

### DIFF
--- a/src/Serilog.AspNetCore/AspNetCore/RequestLoggingMiddleware.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/RequestLoggingMiddleware.cs
@@ -29,7 +29,7 @@ namespace Serilog.AspNetCore
         readonly RequestDelegate _next;
         readonly DiagnosticContext _diagnosticContext;
         readonly MessageTemplate _messageTemplate;
-        readonly Func<HttpContext, Exception, LogEventLevel> _getLevel;
+        readonly Func<HttpContext, double, Exception, LogEventLevel> _getLevel;
         static readonly LogEventProperty[] NoProperties = new LogEventProperty[0];
 
         public RequestLoggingMiddleware(RequestDelegate next, DiagnosticContext diagnosticContext, RequestLoggingOptions options)
@@ -72,7 +72,7 @@ namespace Serilog.AspNetCore
         bool LogCompletion(HttpContext httpContext, DiagnosticContextCollector collector, int statusCode, double elapsedMs, Exception ex)
         {
             var logger = Log.ForContext<RequestLoggingMiddleware>();
-            var level = _getLevel(httpContext, ex);
+            var level = _getLevel(httpContext, elapsedMs, ex);
 
             if (!logger.IsEnabled(level)) return false;
 

--- a/src/Serilog.AspNetCore/AspNetCore/RequestLoggingOptions.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/RequestLoggingOptions.cs
@@ -35,13 +35,15 @@ namespace Serilog.AspNetCore
         public string MessageTemplate { get; set; }
 
         /// <summary>
-        /// Gets or sets the function returning the <see cref="LogEventLevel"/> based on the <see cref="HttpContext"/> and on the <see cref="Exception" /> if something wrong happend 
-        /// The default behavior returns LogEventLevel.Error when HttpStatusCode is greater than 499 or if Exception is not null.
+        /// Gets or sets the function returning the <see cref="LogEventLevel"/> based on the <see cref="HttpContext"/>, the number of
+        /// elapsed milliseconds required for handling the request, and an <see cref="Exception" /> if one was thrown.
+        /// The default behavior returns <see cref="LogEventLevel.Error"/> when the response status code is greater than 499 or if the
+        /// <see cref="Exception"/> is not null.
         /// </summary>
         /// <value>
         /// The function returning the <see cref="LogEventLevel"/>.
         /// </value>
-        public Func<HttpContext, Exception, LogEventLevel> GetLevel { get; set; }
+        public Func<HttpContext, double, Exception, LogEventLevel> GetLevel { get; set; }
 
         internal RequestLoggingOptions() { }
     }

--- a/src/Serilog.AspNetCore/SerilogApplicationBuilderExtensions.cs
+++ b/src/Serilog.AspNetCore/SerilogApplicationBuilderExtensions.cs
@@ -28,8 +28,8 @@ namespace Serilog
         const string DefaultRequestCompletionMessageTemplate =
             "HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms";
 
-        static Func<HttpContext, Exception, LogEventLevel> DefaultGetLevel =
-            (ctx, ex) => ex != null
+        static readonly Func<HttpContext, double, Exception, LogEventLevel> DefaultGetLevel =
+            (ctx, _, ex) => ex != null
                 ? LogEventLevel.Error 
                 : ctx.Response.StatusCode > 499 
                     ? LogEventLevel.Error 

--- a/src/Serilog.AspNetCore/SerilogApplicationBuilderExtensions.cs
+++ b/src/Serilog.AspNetCore/SerilogApplicationBuilderExtensions.cs
@@ -28,8 +28,8 @@ namespace Serilog
         const string DefaultRequestCompletionMessageTemplate =
             "HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms";
 
-        static readonly Func<HttpContext, double, Exception, LogEventLevel> DefaultGetLevel =
-            (ctx, _, ex) => ex != null
+        static LogEventLevel DefaultGetLevel(HttpContext ctx, double _, Exception ex) =>
+            ex != null
                 ? LogEventLevel.Error 
                 : ctx.Response.StatusCode > 499 
                     ? LogEventLevel.Error 


### PR DESCRIPTION
Follows on from #132, includes request timing information in the level computation.