### PR TITLE
FIX: Enrich context before collecting properties

### DIFF
--- a/src/Serilog.AspNetCore/AspNetCore/RequestLoggingMiddleware.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/RequestLoggingMiddleware.cs
@@ -78,11 +78,11 @@ namespace Serilog.AspNetCore
 
             if (!logger.IsEnabled(level)) return false;
 
-            if (!collector.TryComplete(out var collectedProperties))
-                collectedProperties = NoProperties;
-
             // Enrich diagnostic context
             _enrichDiagnosticContext?.Invoke(_diagnosticContext, httpContext);
+
+            if (!collector.TryComplete(out var collectedProperties))
+                collectedProperties = NoProperties;
 
             // Last-in (correctly) wins...
             var properties = collectedProperties.Concat(new[]


### PR DESCRIPTION
LogCompletion event was not including properties added via
`EnrichDiagnosticContext` delegate on options because
the properties had been collected before invoking the enricher.

Swapping the order of the statements fixes this.

This is a fix for https://github.com/serilog/serilog-aspnetcore/issues/148

I'm afraid I haven't had time to add a test for this. I have built the package locally and tested it with the project I am currently working on.