### PR TITLE
Add LoggerConfiguration in IServiceCollection

### DIFF
--- a/src/Serilog.AspNetCore/SerilogWebHostBuilderExtensions.cs
+++ b/src/Serilog.AspNetCore/SerilogWebHostBuilderExtensions.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
 using Serilog.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Serilog.Extensions.Hosting;
 
 namespace Serilog
@@ -65,7 +66,7 @@ namespace Serilog
                     collection.AddSingleton<ILoggerFactory>(services => new SerilogLoggerFactory(logger, dispose));
                 }
 
-                ConfigureServices(collection, logger);
+                ConfigureServices(collection, logger, null);
             });
 
             return builder;
@@ -131,12 +132,12 @@ namespace Serilog
                     return factory;
                 });
 
-                ConfigureServices(collection, logger);
+                ConfigureServices(collection, logger, loggerConfiguration);
             });
             return builder;
         }
         
-        static void ConfigureServices(IServiceCollection collection, ILogger logger)
+        static void ConfigureServices(IServiceCollection collection, ILogger logger, LoggerConfiguration configuration)
         {
             if (collection == null) throw new ArgumentNullException(nameof(collection));
 
@@ -154,6 +155,12 @@ namespace Serilog
 
             // Consumed by user code
             collection.AddSingleton<IDiagnosticContext>(diagnosticContext);
+
+            // May be consumed by user code
+            if (configuration != null)
+            {
+                collection.TryAddSingleton(configuration);
+            }
         }
     }
 }


### PR DESCRIPTION
@nblumhardt I found that I can solve the problem I described in #130 much easier. I just need to add `LoggerConfiguration` to the container. I see that this is already happening with `IDiagnosticContext` `DiagnosticContext` and `ILogger` so I think there will be nothing wrong with adding `LoggerConfiguration`. Also note that I use `TryAddSingleton` to avoid potential problems with already added configuration.