### PR TITLE
Add async version of diagnostic context enricher callback.

### DIFF
--- a/src/Serilog.AspNetCore/AspNetCore/RequestLoggingOptions.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/RequestLoggingOptions.cs
@@ -15,6 +15,7 @@
 using Microsoft.AspNetCore.Http;
 using Serilog.Events;
 using System;
+using System.Threading.Tasks;
 
 namespace Serilog.AspNetCore
 {
@@ -49,6 +50,12 @@ namespace Serilog.AspNetCore
         /// A callback that can be used to set additional properties on the request completion event.
         /// </summary>
         public Action<IDiagnosticContext, HttpContext> EnrichDiagnosticContext { get; set; }
+
+        /// <summary>
+        /// An asynchronous callback that can be used to set additional properties on the request completion event.
+        /// Executed after the synchronous callback if both are provided.
+        /// </summary>
+        public Func<IDiagnosticContext, HttpContext, Task> EnrichDiagnosticContextAsync { get; set; }
 
         internal RequestLoggingOptions() { }
     }


### PR DESCRIPTION
Reasoning:

Accessing the request or response streams to potentially include them in these logs in ASP.NET Core 3.1 is problematic using the existing call, since [3.1 doesn't want you to access these synchronously](https://github.com/dotnet/aspnetcore/issues/7644).  Forcing a global option to be set or wrapping the async calls in the existing sync callback for this seems inelegant.  Provide an async version for the callback in a non-breaking fashion as an option.  Perhaps mark sync version as obsolete and move to async in the future, as middleware framework is async?