### PR TITLE
Pin .NET Core SDK version to latest feature band

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "3.1.102"
+    "allowPrerelease": false,
+    "version": "3.1.100",
+    "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
Pin the .NET Core SDK version to the `3.1.1xx` feature band. Do not
allow prerelease versions.

Fixes #175