### PR TITLE
Fallback RequestPath for when IHttpRequestFeature.RawTarteg is empty

### DIFF
--- a/src/Serilog.AspNetCore/AspNetCore/RequestLoggingMiddleware.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/RequestLoggingMiddleware.cs
@@ -106,7 +106,13 @@ namespace Serilog.AspNetCore
 
         static string GetPath(HttpContext httpContext)
         {
-            return httpContext.Features.Get<IHttpRequestFeature>()?.RawTarget ?? httpContext.Request.Path.ToString();
+            var requestPath = httpContext.Features.Get<IHttpRequestFeature>()?.RawTarget;
+            if (string.IsNullOrWhiteSpace(requestPath))
+            {
+                requestPath = httpContext.Request.Path.ToString();
+            }
+            
+            return requestPath;
         }
     }
 }

--- a/src/Serilog.AspNetCore/AspNetCore/RequestLoggingMiddleware.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/RequestLoggingMiddleware.cs
@@ -106,8 +106,13 @@ namespace Serilog.AspNetCore
 
         static string GetPath(HttpContext httpContext)
         {
+            /*
+                In some cases, like when running integration tests with WebApplicationFactory<T>
+                the RawTarget returns an empty string instead of null, in that case we can't use
+                ?? as fallback.
+            */
             var requestPath = httpContext.Features.Get<IHttpRequestFeature>()?.RawTarget;
-            if (string.IsNullOrWhiteSpace(requestPath))
+            if (string.IsNullOrEmpty(requestPath))
             {
                 requestPath = httpContext.Request.Path.ToString();
             }


### PR DESCRIPTION
When running integration tests using the WebApplicationFactory class, I noticed that the code `httpContext.Features.Get<IHttpRequestFeature>()?.RawTarget` returns an empty string instead of null, which causes the fallback never executing and displaying no path information.