### PR TITLE
Update to show new UseSerilog() overload including service provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,13 +192,13 @@ app.UseSerilogRequestLogging(options =>
 You can alternatively configure Serilog inline, in `BuildWebHost()`, using a delegate as shown below:
 
 ```csharp
-    .UseSerilog((hostingContext, loggerConfiguration) => loggerConfiguration
+    .UseSerilog((hostingContext, services, loggerConfiguration) => loggerConfiguration
         .ReadFrom.Configuration(hostingContext.Configuration)
         .Enrich.FromLogContext()
         .WriteTo.Console())
 ```
 
-This has the advantage of making the `hostingContext`'s `Configuration` object available for [configuration of the logger](https://github.com/serilog/serilog-settings-configuration), but at the expense of losing `Exception`s raised earlier in program startup.
+This has the advantage of making a service provider and the `hostingContext`'s `Configuration` object available for [configuration of the logger](https://github.com/serilog/serilog-settings-configuration), but at the expense of losing `Exception`s raised earlier in program startup.
 
 If this method is used, `Log.Logger` is assigned implicitly, and closed when the app is shut down.
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "allowPrerelease": false,
-    "version": "3.1.100",
+    "version": "3.1.201",
     "rollForward": "latestPatch"
   }
 }

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": false,
     "version": "3.1.201",
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }

--- a/samples/InlineInitializationSample/Program.cs
+++ b/samples/InlineInitializationSample/Program.cs
@@ -13,7 +13,7 @@ namespace InlineInitializationSample
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); })
+                .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>())
                 .UseSerilog((hostingContext, services, loggerConfiguration) => loggerConfiguration
                     .ReadFrom.Configuration(hostingContext.Configuration)
                     .Enrich.FromLogContext()

--- a/samples/InlineInitializationSample/Program.cs
+++ b/samples/InlineInitializationSample/Program.cs
@@ -13,11 +13,8 @@ namespace InlineInitializationSample
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(webBuilder =>
-                {
-                    webBuilder.UseStartup<Startup>();
-                })
-                .UseSerilog((hostingContext, loggerConfiguration) => loggerConfiguration
+                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); })
+                .UseSerilog((hostingContext, services, loggerConfiguration) => loggerConfiguration
                     .ReadFrom.Configuration(hostingContext.Configuration)
                     .Enrich.FromLogContext()
                     .WriteTo.Debug()

--- a/samples/InlineInitializationSample/Startup.cs
+++ b/samples/InlineInitializationSample/Startup.cs
@@ -1,10 +1,8 @@
-using System.Net;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
-using Serilog.Events;
 
 namespace InlineInitializationSample
 {

--- a/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
+++ b/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Serilog support for ASP.NET Core logging</Description>
-    <VersionPrefix>3.3.0</VersionPrefix>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <Authors>Microsoft;Serilog Contributors</Authors>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0-dev-*" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.1" />


### PR DESCRIPTION
Shows the new `UseSerilog()` inline overload from https://github.com/serilog/serilog-extensions-hosting/pull/20