### PR TITLE
Allow RequestLoggingOptions configuration outside of Configure(IApplicationBuilder)

### DIFF
--- a/samples/InlineInitializationSample/Startup.cs
+++ b/samples/InlineInitializationSample/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
+using Serilog.AspNetCore;
 
 namespace InlineInitializationSample
 {
@@ -10,6 +11,14 @@ namespace InlineInitializationSample
     {
         public void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<RequestLoggingOptions>(o =>
+            {
+                o.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
+                {
+                    diagnosticContext.Set("RemoteIpAddress", httpContext.Connection.RemoteIpAddress.MapToIPv4());
+                };
+            });
+
             services.AddControllersWithViews();
         }
 

--- a/src/Serilog.AspNetCore/AspNetCore/RequestLoggingOptions.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/RequestLoggingOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2019 Serilog Contributors
+﻿// Copyright 2019-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,10 +21,20 @@ using System;
 namespace Serilog.AspNetCore
 {
     /// <summary>
-    /// Contains options for the <see cref="Serilog.AspNetCore.RequestLoggingMiddleware"/>.
+    /// Contains options for the <see cref="RequestLoggingMiddleware"/>.
     /// </summary>
     public class RequestLoggingOptions
     {
+        const string DefaultRequestCompletionMessageTemplate =
+            "HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms";
+
+        static LogEventLevel DefaultGetLevel(HttpContext ctx, double _, Exception ex) =>
+            ex != null
+                ? LogEventLevel.Error
+                : ctx.Response.StatusCode > 499
+                    ? LogEventLevel.Error
+                    : LogEventLevel.Information;
+
         /// <summary>
         /// Gets or sets the message template. The default value is
         /// <c>"HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms"</c>. The
@@ -52,13 +62,19 @@ namespace Serilog.AspNetCore
         /// </summary>
         public Action<IDiagnosticContext, HttpContext> EnrichDiagnosticContext { get; set; }
 
-
         /// <summary>
         /// The logger through which request completion events will be logged. The default is to use the
         /// static <see cref="Log"/> class.
         /// </summary>
         public ILogger Logger { get; set; }
 
-        internal RequestLoggingOptions() { }
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public RequestLoggingOptions()
+        {
+            GetLevel = DefaultGetLevel;
+            MessageTemplate = DefaultRequestCompletionMessageTemplate;
+        }
     }
 }

--- a/test/Serilog.AspNetCore.Tests/Serilog.AspNetCore.Tests.csproj
+++ b/test/Serilog.AspNetCore.Tests/Serilog.AspNetCore.Tests.csproj
@@ -14,9 +14,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" PrivateAssets="All" />
     <PackageReference Include="xunit" Version="2.4.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.3" />
   </ItemGroup>
 
 </Project>

--- a/test/Serilog.AspNetCore.Tests/SerilogWebHostBuilderExtensionsTests.cs
+++ b/test/Serilog.AspNetCore.Tests/SerilogWebHostBuilderExtensionsTests.cs
@@ -1,16 +1,103 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
 using Xunit;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Builder;
+
+using Serilog.Filters;
+using Serilog.AspNetCore.Tests.Support;
 
 namespace Serilog.AspNetCore.Tests
 {
-    public class SerilogWebHostBuilderExtensionsTests
+    public class SerilogWebHostBuilderExtensionsTests : IClassFixture<SerilogWebApplicationFactory>
     {
-        [Fact]
-        public void Todo()
-        {
+        SerilogWebApplicationFactory _web;
 
+        public SerilogWebHostBuilderExtensionsTests(SerilogWebApplicationFactory web)
+        {
+            _web = web;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task DisposeShouldBeHandled(bool dispose)
+        {
+            var logger = new DisposeTrackingLogger();
+            using (var web = Setup(logger, dispose))
+            {
+                await web.CreateClient().GetAsync("/");
+            }
+
+            Assert.Equal(dispose, logger.IsDisposed);
+        }
+
+        [Fact]
+        public async Task RequestLoggingMiddlewareShouldEnrich()
+        {
+            var (sink, web) = Setup(options =>
+            {
+                options.EnrichDiagnosticContext += (diagnosticContext, httpContext) =>
+                {
+                    diagnosticContext.Set("SomeInteger", 42);
+                };
+            });
+
+            await web.CreateClient().GetAsync("/resource");
+
+            Assert.NotEmpty(sink.Writes);
+
+            var completionEvent = sink.Writes.Where(logEvent => Matching.FromSource<RequestLoggingMiddleware>()(logEvent)).FirstOrDefault();
+
+            Assert.Equal(42, completionEvent.Properties["SomeInteger"].LiteralValue());
+            Assert.Equal("string", completionEvent.Properties["SomeString"].LiteralValue());
+            Assert.Equal("/resource", completionEvent.Properties["RequestPath"].LiteralValue());
+            Assert.Equal(200, completionEvent.Properties["StatusCode"].LiteralValue());
+            Assert.Equal("GET", completionEvent.Properties["RequestMethod"].LiteralValue());
+            Assert.True(completionEvent.Properties.ContainsKey("Elapsed"));
+        }
+
+        WebApplicationFactory<TestStartup> Setup(ILogger logger, bool dispose, Action<RequestLoggingOptions> configureOptions = null)
+        {
+            var web = _web.WithWebHostBuilder(
+                builder => builder
+                    .ConfigureServices(sc => sc.Configure<RequestLoggingOptions>(options =>
+                    {
+                        options.Logger = logger;
+                        options.EnrichDiagnosticContext += (diagnosticContext, httpContext) =>
+                        {
+                            diagnosticContext.Set("SomeString", "string");
+                        };
+                    }))
+                    .Configure(app =>
+                    {
+                        app.UseSerilogRequestLogging(configureOptions);
+                        app.Run(_ => Task.CompletedTask); // 200 OK
+                    })
+                    .UseSerilog(logger, dispose));
+
+            return web;
+        }
+
+        (SerilogSink, WebApplicationFactory<TestStartup>) Setup(Action<RequestLoggingOptions> configureOptions = null)
+        {
+            var sink = new SerilogSink();
+            var logger = new LoggerConfiguration()
+                .Enrich.FromLogContext()
+                .WriteTo.Sink(sink)
+                .CreateLogger();
+
+            var web = Setup(logger, true, configureOptions);
+
+            return (sink, web);
         }
     }
 }

--- a/test/Serilog.AspNetCore.Tests/Support/Extensions.cs
+++ b/test/Serilog.AspNetCore.Tests/Support/Extensions.cs
@@ -1,0 +1,12 @@
+﻿using Serilog.Events;
+
+namespace Serilog.AspNetCore.Tests.Support
+{
+    public static class Extensions
+    {
+        public static object LiteralValue(this LogEventPropertyValue @this)
+        {
+            return ((ScalarValue)@this).Value;
+        }
+    }
+}

--- a/test/Serilog.AspNetCore.Tests/Support/SerilogWebApplicationFactory.cs
+++ b/test/Serilog.AspNetCore.Tests/Support/SerilogWebApplicationFactory.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Serilog.AspNetCore.Tests.Support
+{
+    public class SerilogWebApplicationFactory : WebApplicationFactory<TestStartup>
+    {
+        protected override IWebHostBuilder CreateWebHostBuilder() => new WebHostBuilder().UseStartup<TestStartup>();
+        protected override void ConfigureWebHost(IWebHostBuilder builder) => builder.UseContentRoot(".");
+    }
+
+    public class TestStartup { }
+}


### PR DESCRIPTION
It is a common pattern to configure middleware options outside of `Configure(IApplicationBuilder)`. It could be a different module, for example. It also integrates with `Microsoft.Extensions.Options`. This PR will allow such configuration:

```csharp
public void ConfigureServices(IServiceCollection services)
{
    services.Configure<RequestLoggingOptions>(Configuration.GetSection("Serilog")); // get MessageTemplate from appsettings.json
    services.PostConfigure<RequestLoggingOptions>(options =>
    {
        options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
        {
            diagnosticContext.Set("RemoteIpAddress", httpContext.Connection.RemoteIpAddress.MapToIPv4());
        };
    });
}

public void Configure(IApplicationBuilder app)
{
    // ..
    app.UseSerilogRequestLogging();
    app.UseRouting();
    // ...
}
```