### PR TITLE
Add using statement to readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ To use this technique, first replace the initial `CreateLogger()` call with `Cre
 
 ```csharp
 using Serilog;
+using Serilog.Events;
 
 public class Program
 {


### PR DESCRIPTION
`LogEventLevel.Information` requires `using Serilog.Events;`