### PR TITLE
Log exception set in IDiagnosticContext

### DIFF
--- a/src/Serilog.AspNetCore/AspNetCore/RequestLoggingMiddleware.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/RequestLoggingMiddleware.cs
@@ -86,7 +86,7 @@ namespace Serilog.AspNetCore
             // Enrich diagnostic context
             _enrichDiagnosticContext?.Invoke(_diagnosticContext, httpContext);
 
-            if (!collector.TryComplete(out var collectedProperties))
+            if (!collector.TryComplete(out var collectedProperties, out var collectedException))
                 collectedProperties = NoProperties;
 
             // Last-in (correctly) wins...
@@ -98,7 +98,7 @@ namespace Serilog.AspNetCore
                 new LogEventProperty("Elapsed", new ScalarValue(elapsedMs))
             });
 
-            var evt = new LogEvent(DateTimeOffset.Now, level, ex, _messageTemplate, properties);
+            var evt = new LogEvent(DateTimeOffset.Now, level, ex ?? collectedException, _messageTemplate, properties);
             logger.Write(evt);
 
             return false;

--- a/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
+++ b/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
@@ -30,7 +30,7 @@
   
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.1-dev-00092" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />


### PR DESCRIPTION
Fixes: serilog/serilog-aspnetcore#270
Depends on: https://github.com/serilog/serilog-extensions-hosting/pull/56

### Changes
- `RequestLoggingMiddleware.LogCompletion` enriches with the exception set in `IDiagnosticContext`, unless an unhandled exception takes precedence.

### Testing
- Add tests on enriching with collected exception and favoring unhandled exception
- Functionally tested and Serilog request log event is correctly enriched with exception set in `IDiagnosticContext`

![chrome_7VOs0WYLjb_masked](https://user-images.githubusercontent.com/787816/140400590-6119e504-9136-4795-9573-025b6e18e9ee.png)
