### PR TITLE
Bump Serilog.Settings.Configuration to latest version (3.3.0)

### DIFF
--- a/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
+++ b/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
We are trying to use some of the latest functionalities from `Serilog.Settings.Configuration`. It would be good to use the transitive dependency instead of forcing the latest manually.

I reckon this is a fairly safe PR. Let me know if I need to add something else.