### PR TITLE
6.0.1 Release

### DIFF
--- a/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
+++ b/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
@@ -30,7 +30,7 @@
   
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.0-dev-*" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />


### PR DESCRIPTION
Updates _Serilog.Extensions.Hosting_ to [5.0.1](https://github.com/serilog/serilog-extensions-hosting/releases/tag/v5.0.1)