### PR TITLE
Add EnrichDiagnosticContextAsync to allow async calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ app.UseSerilogRequestLogging(options =>
         diagnosticContext.Set("RequestHost", httpContext.Request.Host.Value);
         diagnosticContext.Set("RequestScheme", httpContext.Request.Scheme);
     };
+    
+    // Use an async method to add additional properties that can only be retrieved 
+    // asynchronously like request body
+    options.EnrichDiagnosticContextAsync = async (diagnosticContext, httpContext) =>
+    {
+        await AddRequestBodyAsync(diagnosticContext, httpContext);
+    };
 });
 ```
 

--- a/src/Serilog.AspNetCore/AspNetCore/RequestLoggingOptions.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/RequestLoggingOptions.cs
@@ -69,6 +69,14 @@ public class RequestLoggingOptions
     /// A callback that can be used to set additional properties on the request completion event.
     /// </summary>
     public Action<IDiagnosticContext, HttpContext>? EnrichDiagnosticContext { get; set; }
+    
+    /// <summary>
+    /// An async callback that can be used to set additional properties on the request completion event.
+    /// Can be used in addition to <see cref="EnrichDiagnosticContext"/> if you need async calls (e.g. for getting the
+    /// request body) and will be called before the synchronous method.
+    /// </summary>
+    /// <remarks>Execution is not guaranteed if an exception occurs during finalizing the diagnostic entries.</remarks>
+    public Func<IDiagnosticContext, HttpContext, Task>? EnrichDiagnosticContextAsync { get; set; }
 
     /// <summary>
     /// The logger through which request completion events will be logged. The default is to use the


### PR DESCRIPTION
https://github.com/serilog/serilog-aspnetcore/issues/345

If you want to add properties to the diagnostic context that require async calls (e.g. reading request body), EnrichDiagnosticContextAsync allows to hand over your own async method.