### PR TITLE
Collect trace and span ids in request completion events

### DIFF
--- a/samples/Sample/Program.cs
+++ b/samples/Sample/Program.cs
@@ -1,4 +1,5 @@
 using Serilog;
+using Serilog.Templates;
 
 namespace Sample;
 
@@ -39,6 +40,8 @@ public static class Program
                 .ReadFrom.Configuration(context.Configuration)
                 .ReadFrom.Services(services)
                 .Enrich.FromLogContext()
-                .WriteTo.Console())
+                .WriteTo.Console(new ExpressionTemplate(
+                    // Include trace and span ids when present.
+                    "[{@t:HH:mm:ss} {@l:u3}{#if @tr is not null} ({@tr}:{@sp}){#end}] {@m}\n{@x}")))
             .ConfigureWebHostDefaults(webBuilder => webBuilder.UseStartup<Startup>());
 }

--- a/samples/Sample/Sample.csproj
+++ b/samples/Sample/Sample.csproj
@@ -7,5 +7,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog.AspNetCore\Serilog.AspNetCore.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Serilog.Expressions" Version="4.0.0-*" />
+  </ItemGroup>
 
 </Project>

--- a/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
+++ b/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Serilog support for ASP.NET Core logging</Description>
     <!-- This must match the major and minor components of the referenced *.Extensions.* packages (and highest supported .NET TFM). -->
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>7.0.1</VersionPrefix>
     <Authors>Microsoft;Serilog Contributors</Authors>
     <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog" Version="3.1.0-*" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />

--- a/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
+++ b/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="2.0.0-*" />
   </ItemGroup>
 
   <ItemGroup>
@@ -36,6 +36,8 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <!-- Temporary addition to pull in trace/span support -->
+    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.1-*" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net462' and '$(TargetFramework)' != 'netstandard2.0' and '$(TargetFramework)' != 'netstandard2.1' ">

--- a/test/Serilog.AspNetCore.Tests/SerilogWebHostBuilderExtensionsTests.cs
+++ b/test/Serilog.AspNetCore.Tests/SerilogWebHostBuilderExtensionsTests.cs
@@ -164,6 +164,19 @@ public class SerilogWebHostBuilderExtensionsTests : IClassFixture<SerilogWebAppl
 
         return web;
     }
+    
+    [Fact]
+    public async Task RequestLoggingMiddlewareShouldAddTraceAndSpanIds()
+    {
+        var (sink, web) = Setup();
+
+        await web.CreateClient().GetAsync("/resource");
+
+        var completionEvent = sink.Writes.First(logEvent => Matching.FromSource<RequestLoggingMiddleware>()(logEvent));
+
+        Assert.NotNull(completionEvent.TraceId);
+        Assert.NotNull(completionEvent.SpanId);
+    }
 
     (SerilogSink, WebApplicationFactory<TestStartup>) Setup(
         Action<RequestLoggingOptions>? configureOptions = null,


### PR DESCRIPTION
Reported in: https://github.com/serilog/serilog-aspnetcore/issues/207#issuecomment-1756844594

The dependencies and their versions here are temporary, we'll soon be updating this package to .NET 8 and will ideally RTM the upstream pieces then, too.