### PR TITLE
Upgrade Serilog.Settings.Configuration to fix a System.Text.Json security vulnerability.

### DIFF
--- a/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
+++ b/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <!-- The versions of all references in this group must match the major and minor components of the package version prefix. -->
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <!-- Temporary addition to pull in trace/span support -->


### PR DESCRIPTION
Upgrading the package **_Serilog.Settings.Configuration_** fixes the Denial of Service (DoS) security vulnerability detected on the dependencies of System.Text.Json@8.0.0.

> Serilog.AspNetCore@8.0.1 >
> Serilog.Settings.Configuration@8.0.0 >
> Microsoft.Extensions.DependencyModel@8.0.0 >
> System.Text.Json@8.0.0

https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMTEXTJSON-7433719