### PR TITLE
Update docs to help consumers use async flushing/disposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ try
     var app = builder.Build();
     app.MapGet("/", () => "Hello World!");
 
-    app.Run();
+    await app.RunAsync();
 }
 catch (Exception ex)
 {
@@ -44,7 +44,7 @@ catch (Exception ex)
 }
 finally
 {
-    Log.CloseAndFlush();
+    await Log.CloseAndFlushAsync();
 }
 ```
 

--- a/samples/Sample/Program.cs
+++ b/samples/Sample/Program.cs
@@ -65,5 +65,5 @@ catch (Exception ex)
 }
 finally
 {
-    Log.CloseAndFlush();
+    await Log.CloseAndFlushAsync();
 }

--- a/test/Serilog.AspNetCore.Tests/SerilogWebHostBuilderExtensionsTests.cs
+++ b/test/Serilog.AspNetCore.Tests/SerilogWebHostBuilderExtensionsTests.cs
@@ -38,6 +38,20 @@ public class SerilogWebHostBuilderExtensionsTests : IClassFixture<SerilogWebAppl
 
         Assert.Equal(dispose, logger.IsDisposed);
     }
+    
+    [Fact]
+    public async Task DisposeAsyncShouldBeHandled()
+    {
+        var logger = new DisposeTrackingLogger();
+        await using (var web = Setup(logger, dispose: true))
+        {
+            await web.CreateClient().GetAsync("/");
+        }
+
+        Assert.Multiple(
+            () => Assert.True(logger.IsDisposedAsync),
+            () => Assert.False(logger.IsDisposed));
+    }
 
     [Fact]
     public async Task RequestLoggingMiddlewareShouldEnrich()

--- a/test/Serilog.AspNetCore.Tests/Support/DisposeTrackingLogger.cs
+++ b/test/Serilog.AspNetCore.Tests/Support/DisposeTrackingLogger.cs
@@ -4,9 +4,10 @@ using Serilog.Events;
 
 namespace Serilog.AspNetCore.Tests.Support;
 
-sealed class DisposeTrackingLogger : ILogger, IDisposable
+sealed class DisposeTrackingLogger : ILogger, IDisposable, IAsyncDisposable
 {
     public bool IsDisposed { get; private set; }
+    public bool IsDisposedAsync { get; private set; }
 
     public ILogger ForContext(ILogEventEnricher enricher)
     {
@@ -351,5 +352,11 @@ sealed class DisposeTrackingLogger : ILogger, IDisposable
     public void Dispose()
     {
         IsDisposed = true;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        IsDisposedAsync = true;
+        return default;
     }
 }


### PR DESCRIPTION
Also add a test that shows logger is currently not disposed asynchronously. Should be fixed with https://github.com/serilog/serilog-extensions-logging/pull/262.