### PR TITLE
Update deprecated NuGet packages Microsoft.AspNetCore.* 

### DIFF
--- a/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
+++ b/src/Serilog.AspNetCore/Serilog.AspNetCore.csproj
@@ -39,8 +39,8 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update Microsoft.AspNetCore.Hosting.Abstractions and Microsoft.AspNetCore.Http.Abstractions to 2.3.0

Fixes #398 