### PR TITLE
Add request body logging to middleware

### DIFF
--- a/src/Serilog.AspNetCore/AspNetCore/RequestLoggingOptions.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/RequestLoggingOptions.cs
@@ -82,6 +82,33 @@ public class RequestLoggingOptions
     public bool IncludeQueryInRequestPath { get; set; }
 
     /// <summary>
+    /// Include the request body in the log event. The default is <c>false</c>.
+    /// </summary>
+    /// <remarks>
+    /// If set to <c>true</c>, the request body will be buffered and read in order to include it
+    /// in the log event. This may have performance implications and may not be suitable for large request bodies.
+    /// </remarks>
+    public bool IncludeRequestBody { get; set; }
+
+    /// <summary>
+    /// The content types for which the request body should be included in the log event.
+    /// The default is <c>application/json</c>.
+    /// </summary>
+    /// <remarks>
+    /// Only used if <see cref="IncludeRequestBody"/> is set to <c>true</c>.
+    /// </remarks>
+    public List<string> RequestBodyContentTypes { get; set; } = ["application/json"];
+
+    /// <summary>
+    /// The maximum length of the request body content to include in the log event.
+    /// The default is 8 KB. Set to <c>null</c> for no limit.
+    /// </summary>
+    /// <remarks>
+    /// Only used if <see cref="IncludeRequestBody"/> is set to <c>true</c>.
+    /// </remarks>
+    public long? RequestBodyContentMaxLength { get; set; } = 8 * 1024; // 8 KB
+
+    /// <summary>
     /// A function to specify the values of the MessageTemplateProperties.
     /// </summary>
     public Func<HttpContext, string, double, int, IEnumerable<LogEventProperty>> GetMessageTemplateProperties { get; set; }


### PR DESCRIPTION
This pull request adds support for logging HTTP request bodies in the `RequestLoggingMiddleware`, with configurable options for when and how much of the body to log. It also introduces tests to ensure this functionality works as expected and remains off by default unless enabled.

**Request body logging enhancements:**

* Added `IncludeRequestBody`, `RequestBodyContentTypes`, and `RequestBodyContentMaxLength` options to `RequestLoggingOptions`, allowing users to opt-in to logging request bodies, specify which content types to log, and set a maximum length for logged bodies. 
* Implemented logic in `RequestLoggingMiddleware` to read, buffer, and log the request body based on the new options, with support for both .NET 5+ and older frameworks. This includes handling content type filtering and size limits, and ensures the request body stream is reset for further processing. 

**Testing improvements:**

* Added tests to verify that the request body is not logged by default and is logged correctly when `IncludeRequestBody` is enabled, including content verification for JSON payloads. Enhanced `RequestLoggingMiddleware` to log request bodies based on new `RequestLoggingOptions`. Introduced `CollectRequestBody` method to handle body collection, ensuring logging only for specified content types and within a maximum length. Updated `RequestLoggingOptions` with `IncludeRequestBody`, `RequestBodyContentTypes`, and `RequestBodyContentMaxLength` properties for configuration.

* Added tests in `SerilogWebHostBuilderExtensionsTests` to verify request body logging functionality and ensure backward compatibility with .NET versions.