### PR TITLE
Suppress exceptions for aborted requests

### DIFF
--- a/src/Serilog.AspNetCore/AspNetCore/RequestLoggingMiddleware.cs
+++ b/src/Serilog.AspNetCore/AspNetCore/RequestLoggingMiddleware.cs
@@ -94,10 +94,16 @@ class RequestLoggingMiddleware
             (activity.TraceId, activity.SpanId) :
             (default(ActivityTraceId), default(ActivitySpanId));
 
+        var isRequestAborted =
+            (ex is OperationCanceledException || ex is IOException) &&
+            httpContext.RequestAborted.IsCancellationRequested;
+
+        var eventException = isRequestAborted ? collectedException : ex ?? collectedException;
+
         var evt = new LogEvent(
             DateTimeOffset.Now,
             level,
-            ex ?? collectedException,
+            eventException,
             _messageTemplate,
             properties,
             traceId,

--- a/test/Serilog.AspNetCore.Tests/SerilogWebHostBuilderExtensionsTests.cs
+++ b/test/Serilog.AspNetCore.Tests/SerilogWebHostBuilderExtensionsTests.cs
@@ -134,6 +134,68 @@ public class SerilogWebHostBuilderExtensionsTests : IClassFixture<SerilogWebAppl
         Assert.Same(unhandledException, thrownException);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task RequestLoggingMiddlewareShouldNotEnrichWithExceptionWhenRequestIsAborted(bool useIOException)
+    {
+        Exception abortedException = useIOException
+            ? new IOException("Request aborted")
+            : new OperationCanceledException("Request aborted");
+        var (sink, web) = Setup(actionCallback: context =>
+        {
+            context.RequestAborted = new CancellationToken(canceled: true);
+            throw abortedException;
+        });
+
+        Func<Task> act = () => web.CreateClient().GetAsync("/resource");
+
+        var thrownException = await Assert.ThrowsAnyAsync<Exception>(act);
+        var completionEvent = sink.Writes.First(logEvent => Matching.FromSource<RequestLoggingMiddleware>()(logEvent));
+        Assert.Null(completionEvent.Exception);
+        Assert.Same(abortedException, thrownException);
+        Assert.Equal(LogEventLevel.Error, completionEvent.Level);
+    }
+
+    [Fact]
+    public async Task RequestLoggingMiddlewareShouldEnrichWithCancellationExceptionWhenRequestIsNotAborted()
+    {
+        var cancellationException = new OperationCanceledException("Request canceled");
+        var (sink, web) = Setup(actionCallback: _ => throw cancellationException);
+
+        Func<Task> act = () => web.CreateClient().GetAsync("/resource");
+
+        var thrownException = await Assert.ThrowsAsync<OperationCanceledException>(act);
+        var completionEvent = sink.Writes.First(logEvent => Matching.FromSource<RequestLoggingMiddleware>()(logEvent));
+        Assert.Same(cancellationException, completionEvent.Exception);
+        Assert.Same(cancellationException, thrownException);
+    }
+
+    [Fact]
+    public async Task RequestLoggingMiddlewareShouldPreserveCollectedExceptionWhenRequestIsAborted()
+    {
+        var collectedException = new Exception("Exception set in diagnostic context");
+        var escapingException = new OperationCanceledException("Request aborted");
+        var (sink, web) = Setup(options =>
+        {
+            options.EnrichDiagnosticContext += (diagnosticContext, _) =>
+            {
+                diagnosticContext.SetException(collectedException);
+            };
+        }, actionCallback: context =>
+        {
+            context.RequestAborted = new CancellationToken(canceled: true);
+            throw escapingException;
+        });
+
+        Func<Task> act = () => web.CreateClient().GetAsync("/resource");
+
+        var thrownException = await Assert.ThrowsAsync<OperationCanceledException>(act);
+        var completionEvent = sink.Writes.First(logEvent => Matching.FromSource<RequestLoggingMiddleware>()(logEvent));
+        Assert.Same(collectedException, completionEvent.Exception);
+        Assert.Same(escapingException, thrownException);
+    }
+
     WebApplicationFactory<TestEntryPoint> Setup(
         ILogger logger,
         bool dispose,


### PR DESCRIPTION
Fixes #372.

## Summary

`RequestLoggingMiddleware` no longer attaches an escaping `OperationCanceledException` or `IOException` to the completion event when `HttpContext.RequestAborted` is cancelled.

The completion event is still emitted, the exception continues to propagate through the middleware pipeline, and exceptions collected through `IDiagnosticContext.SetException()` remain attached.

## Rationale

This follows ASP.NET Core's request-abort handling. `IOException` was included intentionally ([aspnetcore#46330 discussion](https://github.com/dotnet/aspnetcore/pull/46330#discussion_r1099323588)), and the exception is omitted to avoid noisy, non-actionable stack traces ([Tratcher's comment](https://github.com/dotnet/aspnetcore/pull/46330#discussion_r1093576244)).

## Tests

Tests cover both cancellation exception types, non-aborted cancellation, and preservation of collected exceptions.